### PR TITLE
Refactor ScalarBoolean operations into dedicated module

### DIFF
--- a/run_tests.js
+++ b/run_tests.js
@@ -4,6 +4,7 @@ const vm = require('vm');
 
 const distDir = path.join(__dirname, 'dist');
 const files = [
+  'ScalarBoolean.js',
   'VectorBoolean.js',
   'VectorNumber.js',
   'VectorString.js',

--- a/src/ScalarBoolean.ts
+++ b/src/ScalarBoolean.ts
@@ -1,0 +1,23 @@
+interface PokaScalarBoolean {
+  _type: "ScalarBoolean";
+  value: boolean;
+}
+
+function pokaScalarBooleanMake(value: boolean): PokaScalarBoolean {
+  return { _type: "ScalarBoolean", value };
+}
+
+function pokaScalarBooleanEqualsScalarBoolean(
+  a: PokaScalarBoolean,
+  b: PokaScalarBoolean,
+): PokaScalarBoolean {
+  return pokaScalarBooleanMake(a.value === b.value);
+}
+
+function pokaScalarBooleanUnequalsScalarBoolean(
+  a: PokaScalarBoolean,
+  b: PokaScalarBoolean,
+): PokaScalarBoolean {
+  return pokaScalarBooleanMake(a.value !== b.value);
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-interface PokaScalarBoolean {
-  _type: "ScalarBoolean";
-  value: boolean;
-}
 
 interface PokaScalarNumber {
   _type: "ScalarNumber";
@@ -92,9 +88,6 @@ function pokaInterpreterShow(state: InterpreterState): string {
   return state.error + "\n" + result.join("\n");
 }
 
-function pokaScalarBooleanMake(value: boolean): PokaScalarBoolean {
-  return { _type: "ScalarBoolean", value: value };
-}
 
 function pokaScalarNumberMake(value: number): PokaScalarNumber {
   return { _type: "ScalarNumber", value: value };

--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -9,35 +9,35 @@ function pokaRecordEqualsPokaRecord(
   for (const key of allKeys) {
     const aElem = a.value[key];
     if (aElem === undefined) {
-      return { _type: "ScalarBoolean", value: false };
+      return pokaScalarBooleanMake(false);
     }
 
     const bElem = b.value[key];
     if (bElem === undefined) {
-      return { _type: "ScalarBoolean", value: false };
+      return pokaScalarBooleanMake(false);
     }
 
     if (aElem._type === "ScalarBoolean" && bElem._type === "ScalarBoolean") {
-      if (aElem.value !== bElem.value) {
-        return { _type: "ScalarBoolean", value: false };
+      if (!pokaScalarBooleanEqualsScalarBoolean(aElem, bElem).value) {
+        return pokaScalarBooleanMake(false);
       }
     } else if (
       aElem._type === "ScalarNumber" &&
       bElem._type === "ScalarNumber"
     ) {
       if (aElem.value !== bElem.value) {
-        return { _type: "ScalarBoolean", value: false };
+        return pokaScalarBooleanMake(false);
       }
     } else if (
       aElem._type === "ScalarString" &&
       bElem._type === "ScalarString"
     ) {
       if (aElem.value !== bElem.value) {
-        return { _type: "ScalarBoolean", value: false };
+        return pokaScalarBooleanMake(false);
       }
     } else {
       throw "Not Implemented";
     }
   }
-  return { _type: "ScalarBoolean", value: true };
+  return pokaScalarBooleanMake(true);
 }

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -44,7 +44,7 @@ function pokaWordEquals(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarBoolean" && b._type === "ScalarBoolean") {
-    stack.push(pokaScalarBooleanMake(a.value === b.value));
+    stack.push(pokaScalarBooleanEqualsScalarBoolean(a, b));
     return;
   }
 
@@ -685,7 +685,7 @@ function pokaWordUnequals(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarBoolean" && b._type === "ScalarBoolean") {
-    stack.push(pokaScalarBooleanMake(a.value !== b.value));
+    stack.push(pokaScalarBooleanUnequalsScalarBoolean(a, b));
     return;
   }
 


### PR DESCRIPTION
## Summary
- introduce `ScalarBoolean.ts` with helper functions
- use new helpers in `pokaWords` and `pokaRecord`
- load `ScalarBoolean.js` in test runner
- remove old inline implementation from `index.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869385ff4a88332b33233d10fd39d3a