### PR TITLE
Refactor ScalarNumber operations

### DIFF
--- a/run_tests.js
+++ b/run_tests.js
@@ -5,6 +5,7 @@ const vm = require('vm');
 const distDir = path.join(__dirname, 'dist');
 const files = [
   'ScalarBoolean.js',
+  'ScalarNumber.js',
   'VectorBoolean.js',
   'VectorNumber.js',
   'VectorString.js',

--- a/src/ScalarNumber.ts
+++ b/src/ScalarNumber.ts
@@ -1,0 +1,47 @@
+interface PokaScalarNumber {
+  _type: "ScalarNumber";
+  value: number;
+}
+
+function pokaScalarNumberMake(value: number): PokaScalarNumber {
+  return { _type: "ScalarNumber", value };
+}
+
+function pokaScalarNumberAddScalarNumber(
+  a: PokaScalarNumber,
+  b: PokaScalarNumber,
+): PokaScalarNumber {
+  return pokaScalarNumberMake(a.value + b.value);
+}
+
+function pokaScalarNumberSubScalarNumber(
+  a: PokaScalarNumber,
+  b: PokaScalarNumber,
+): PokaScalarNumber {
+  return pokaScalarNumberMake(a.value - b.value);
+}
+
+function pokaScalarNumberMulScalarNumber(
+  a: PokaScalarNumber,
+  b: PokaScalarNumber,
+): PokaScalarNumber {
+  return pokaScalarNumberMake(a.value * b.value);
+}
+
+function pokaScalarNumberAbs(a: PokaScalarNumber): PokaScalarNumber {
+  return pokaScalarNumberMake(Math.abs(a.value));
+}
+
+function pokaScalarNumberEqualsScalarNumber(
+  a: PokaScalarNumber,
+  b: PokaScalarNumber,
+): PokaScalarBoolean {
+  return pokaScalarBooleanMake(a.value === b.value);
+}
+
+function pokaScalarNumberUnequalsScalarNumber(
+  a: PokaScalarNumber,
+  b: PokaScalarNumber,
+): PokaScalarBoolean {
+  return pokaScalarBooleanMake(a.value !== b.value);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,4 @@
 
-interface PokaScalarNumber {
-  _type: "ScalarNumber";
-  value: number;
-}
-
 interface PokaScalarString {
   _type: "ScalarString";
   value: string;
@@ -88,10 +83,6 @@ function pokaInterpreterShow(state: InterpreterState): string {
   return state.error + "\n" + result.join("\n");
 }
 
-
-function pokaScalarNumberMake(value: number): PokaScalarNumber {
-  return { _type: "ScalarNumber", value: value };
-}
 
 function pokaScalarStringMake(value: string): PokaScalarString {
   return { _type: "ScalarString", value: value };
@@ -240,7 +231,7 @@ function consumeNumber(state: InterpreterState): void {
   if (isNaN(value)) {
     throw "`" + token + "` is not a number.";
   } else {
-    state.stack.push({ _type: "ScalarNumber", value: value });
+    state.stack.push(pokaScalarNumberMake(value));
   }
 }
 

--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -25,7 +25,7 @@ function pokaRecordEqualsPokaRecord(
       aElem._type === "ScalarNumber" &&
       bElem._type === "ScalarNumber"
     ) {
-      if (aElem.value !== bElem.value) {
+      if (!pokaScalarNumberEqualsScalarNumber(aElem, bElem).value) {
         return pokaScalarBooleanMake(false);
       }
     } else if (

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -49,7 +49,7 @@ function pokaWordEquals(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarNumber" && b._type === "ScalarNumber") {
-    stack.push(pokaScalarBooleanMake(a.value === b.value));
+    stack.push(pokaScalarNumberEqualsScalarNumber(a, b));
     return;
   }
 
@@ -127,7 +127,7 @@ function pokaWordAdd(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarNumber" && b._type === "ScalarNumber") {
-    stack.push(pokaScalarNumberMake(a.value + b.value));
+    stack.push(pokaScalarNumberAddScalarNumber(a, b));
     return;
   }
 
@@ -168,7 +168,7 @@ function pokaWordSub(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarNumber" && b._type === "ScalarNumber") {
-    stack.push(pokaScalarNumberMake(a.value - b.value));
+    stack.push(pokaScalarNumberSubScalarNumber(a, b));
     return;
   }
 
@@ -237,7 +237,7 @@ function pokaWordAbs(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarNumber") {
-    stack.push(pokaScalarNumberMake(Math.abs(a.value)));
+    stack.push(pokaScalarNumberAbs(a));
     return;
   }
 
@@ -690,7 +690,7 @@ function pokaWordUnequals(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarNumber" && b._type === "ScalarNumber") {
-    stack.push(pokaScalarBooleanMake(a.value !== b.value));
+    stack.push(pokaScalarNumberUnequalsScalarNumber(a, b));
     return;
   }
 
@@ -892,7 +892,7 @@ function pokaWordMul(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarNumber" && b._type === "ScalarNumber") {
-    stack.push(pokaScalarNumberMake(a.value * b.value));
+    stack.push(pokaScalarNumberMulScalarNumber(a, b));
     return;
   }
 


### PR DESCRIPTION
## Summary
- create `ScalarNumber.ts` for scalar number helpers
- centralize ScalarNumber operations and use them throughout the code
- update index number parsing to use helper
- adjust record equality to use ScalarNumber helpers
- update tests loader to include new file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693b2f0fac8332ba8a6e476e68c316