### PR TITLE
Refactor ScalarString operations

### DIFF
--- a/run_tests.js
+++ b/run_tests.js
@@ -6,6 +6,7 @@ const distDir = path.join(__dirname, 'dist');
 const files = [
   'ScalarBoolean.js',
   'ScalarNumber.js',
+  'ScalarString.js',
   'VectorBoolean.js',
   'VectorNumber.js',
   'VectorString.js',

--- a/src/ScalarString.ts
+++ b/src/ScalarString.ts
@@ -1,0 +1,26 @@
+interface PokaScalarString {
+  _type: "ScalarString";
+  value: string;
+}
+
+function pokaScalarStringMake(value: string): PokaScalarString {
+  return { _type: "ScalarString", value };
+}
+
+function pokaScalarStringEqualsScalarString(
+  a: PokaScalarString,
+  b: PokaScalarString,
+): PokaScalarBoolean {
+  return pokaScalarBooleanMake(a.value === b.value);
+}
+
+function pokaScalarStringUnequalsScalarString(
+  a: PokaScalarString,
+  b: PokaScalarString,
+): PokaScalarBoolean {
+  return pokaScalarBooleanMake(a.value !== b.value);
+}
+
+function pokaScalarStringToNumber(a: PokaScalarString): PokaScalarNumber {
+  return pokaScalarNumberMake(parseFloat(a.value));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,4 @@
 
-interface PokaScalarString {
-  _type: "ScalarString";
-  value: string;
-}
-
 interface PokaList {
   _type: "List";
   value: PokaValue[];
@@ -83,10 +78,6 @@ function pokaInterpreterShow(state: InterpreterState): string {
   return state.error + "\n" + result.join("\n");
 }
 
-
-function pokaScalarStringMake(value: string): PokaScalarString {
-  return { _type: "ScalarString", value: value };
-}
 
 function pokaListMake(values: PokaValue[]): PokaList {
   return { _type: "List", value: values };
@@ -254,7 +245,7 @@ function consumeString(state: InterpreterState): void {
   const token = state.line.slice(start, state.pos);
   state.pos++; // Skip closing quote
   const value = token.replace(/\\n/g, "\n");
-  state.stack.push({ _type: "ScalarString", value: value });
+  state.stack.push(pokaScalarStringMake(value));
 }
 
 function peekScope(state: InterpreterState): boolean {

--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -32,7 +32,7 @@ function pokaRecordEqualsPokaRecord(
       aElem._type === "ScalarString" &&
       bElem._type === "ScalarString"
     ) {
-      if (aElem.value !== bElem.value) {
+      if (!pokaScalarStringEqualsScalarString(aElem, bElem).value) {
         return pokaScalarBooleanMake(false);
       }
     } else {

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -54,7 +54,7 @@ function pokaWordEquals(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarString" && b._type === "ScalarString") {
-    stack.push(pokaScalarBooleanMake(a.value === b.value));
+    stack.push(pokaScalarStringEqualsScalarString(a, b));
     return;
   }
 
@@ -391,7 +391,7 @@ function pokaWordToNumber(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarString") {
-    stack.push(pokaScalarNumberMake(parseFloat(a.value)));
+    stack.push(pokaScalarStringToNumber(a));
     return;
   }
 
@@ -695,7 +695,7 @@ function pokaWordUnequals(stack: PokaValue[]): void {
   }
 
   if (a._type === "ScalarString" && b._type === "ScalarString") {
-    stack.push(pokaScalarBooleanMake(a.value !== b.value));
+    stack.push(pokaScalarStringUnequalsScalarString(a, b));
     return;
   }
 


### PR DESCRIPTION
## Summary
- centralize ScalarString helpers in new `ScalarString.ts`
- use helpers for string equality, inequality and conversion
- load new file in `run_tests.js`
- adjust parsing to create ScalarString via helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693e21440883328d8d84376af466e3