### PR TITLE
Add enumerate word

### DIFF
--- a/src/VectorBoolean.ts
+++ b/src/VectorBoolean.ts
@@ -64,3 +64,11 @@ function pokaVectorBooleanWindows(
 
   return pokaMatrixBooleanMake(countRows, size, values);
 }
+
+function pokaVectorBooleanEnumerate(a: PokaVectorBoolean): PokaVectorNumber {
+  const values: number[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    values.push(i);
+  }
+  return pokaVectorNumberMake(values);
+}

--- a/src/VectorNumber.ts
+++ b/src/VectorNumber.ts
@@ -72,6 +72,14 @@ function pokaVectorNumberMulVectorNumber(
   return pokaVectorNumberMake(newVals);
 }
 
+function pokaVectorNumberEnumerate(a: PokaVectorNumber): PokaVectorNumber {
+  const values: number[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    values.push(i);
+  }
+  return pokaVectorNumberMake(values);
+}
+
 function pokaVectorNumberWindows(
   a: PokaVectorNumber,
   size: number,

--- a/src/VectorString.ts
+++ b/src/VectorString.ts
@@ -55,3 +55,11 @@ function pokaVectorStringWindows(
 
   return pokaMatrixStringMake(countRows, size, values);
 }
+
+function pokaVectorStringEnumerate(a: PokaVectorString): PokaVectorNumber {
+  const values: number[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    values.push(i);
+  }
+  return pokaVectorNumberMake(values);
+}

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -527,6 +527,52 @@ POKA_WORDS4["windows"] = {
   fun: pokaWordWindows,
 };
 
+function pokaWordEnumerate(stack: PokaValue[]): void {
+  const a = stack.pop();
+
+  if (a === undefined) {
+    throw "Stack underflow";
+  }
+
+  if (a._type === "List") {
+    const values: number[] = [];
+    for (let i = 0; i < a.value.length; i++) {
+      values.push(i);
+    }
+    stack.push(pokaVectorNumberMake(values));
+    return;
+  }
+
+  const av = pokaTryToVector(a);
+
+  if (av._type === "PokaVectorBoolean") {
+    stack.push(pokaVectorBooleanEnumerate(av));
+    return;
+  }
+
+  if (av._type === "PokaVectorNumber") {
+    stack.push(pokaVectorNumberEnumerate(av));
+    return;
+  }
+
+  if (av._type === "PokaVectorString") {
+    stack.push(pokaVectorStringEnumerate(av));
+    return;
+  }
+
+  throw "No implementation";
+}
+
+POKA_WORDS4["enumerate"] = {
+  doc: [
+    "[1, 2, 3] enumerate [0, 1, 2] equals all",
+    "[True, False] enumerate [0, 1] equals all",
+    "[] enumerate dup equals count 0 equals",
+    '["a", "b", "c"] enumerate [0, 1, 2] equals all',
+  ],
+  fun: pokaWordEnumerate,
+};
+
 function pokaWordLess(stack: PokaValue[]): void {
   const b = stack.pop();
   const a = stack.pop();


### PR DESCRIPTION
## Summary
- support generating index vectors for boolean, number and string vectors
- implement `enumerate` Poka word with doctests
- allow empty lists when enumerating

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697aacd76083329db2c590778f7ebd