### PR TITLE
Add helper functions for record get cases

### DIFF
--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -41,3 +41,50 @@ function pokaRecordEqualsPokaRecord(
   }
   return pokaScalarBooleanMake(true);
 }
+
+function pokaRecordGetScalarString(
+  rec: PokaRecord,
+  key: PokaScalarString,
+): PokaValue {
+  const value = rec.value[key.value];
+  if (value === undefined) {
+    throw "Key not in record";
+  }
+  return value;
+}
+
+function pokaRecordGetVectorString(
+  rec: PokaRecord,
+  keys: PokaVectorString,
+): PokaList {
+  const values: PokaValue[] = [];
+  for (const key of keys.values) {
+    const value = rec.value[key];
+    if (value === undefined) {
+      throw "Key not in record";
+    }
+    values.push(value);
+  }
+  return { _type: "List", value: values };
+}
+
+function pokaRecordGetMatrixString(
+  rec: PokaRecord,
+  keys: PokaMatrixString,
+): PokaList {
+  const rows: PokaList[] = [];
+  let index = 0;
+  for (let r = 0; r < keys.countRows; r++) {
+    const rowVals: PokaValue[] = [];
+    for (let c = 0; c < keys.countCols; c++) {
+      const key = keys.values[index++]!;
+      const value = rec.value[key];
+      if (value === undefined) {
+        throw "Key not in record";
+      }
+      rowVals.push(value);
+    }
+    rows.push({ _type: "List", value: rowVals });
+  }
+  return { _type: "List", value: rows };
+}

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -1005,9 +1005,6 @@ function pokaWordGet(stack: PokaValue[]): void {
   if (b === undefined) {
     throw "Stack underflow";
   }
-  if (b._type !== "ScalarString") {
-    throw "Key must be a ScalarString";
-  }
 
   const a = stack.pop();
   if (a === undefined) {
@@ -1020,16 +1017,32 @@ function pokaWordGet(stack: PokaValue[]): void {
     throw "Record must PokaRecord";
   }
 
-  const value = ar.value[b.value];
-  if (value === undefined) {
-    throw "Key not in record";
+  if (b._type === "ScalarString") {
+    stack.push(pokaRecordGetScalarString(ar, b));
+    return;
   }
 
-  stack.push(value);
+  const bv = pokaTryToVector(b);
+  if (bv._type === "PokaVectorString") {
+    stack.push(pokaRecordGetVectorString(ar, bv));
+    return;
+  }
+
+  const bm = pokaTryToMatrix(b);
+  if (bm._type === "PokaMatrixString") {
+    stack.push(pokaRecordGetMatrixString(ar, bm));
+    return;
+  }
+
+  throw "Key must be a ScalarString";
 }
 
 POKA_WORDS4["get"] = {
-  doc: ['[:"a" 1] "a" get 1 equals'],
+  doc: [
+    '[:"a" 1] "a" get 1 equals',
+    '[:"a" 1, :"b" 2, :"c" 3] ["a", "b", "c"] get [1, 2, 3] equals all',
+    '[:"a" 1, :"b" 2, :"c" 3] [["a", "b", "c"], ["c", "b", "a"]] get [[1, 2, 3], [3, 2, 1]] equals all',
+  ],
   fun: pokaWordGet,
 };
 


### PR DESCRIPTION
## Summary
- add `pokaRecordGetScalarString`, `pokaRecordGetVectorString`, and `pokaRecordGetMatrixString`
- refactor `get` word to delegate to these helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697994fd688332aa2288e3a9bb5e53