### PR TITLE
Implement getTry word for records

### DIFF
--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -68,6 +68,20 @@ function pokaRecordGetVectorString(
   return { _type: "List", value: values };
 }
 
+function pokaRecordGetTryVectorString(
+  rec: PokaRecord,
+  keys: PokaVectorString,
+): PokaList {
+  const values: PokaValue[] = [];
+  for (const key of keys.values) {
+    const value = rec.value[key];
+    if (value !== undefined) {
+      values.push(value);
+    }
+  }
+  return { _type: "List", value: values };
+}
+
 function pokaRecordGetMatrixString(
   rec: PokaRecord,
   keys: PokaMatrixString,

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -1127,6 +1127,39 @@ POKA_WORDS4["get"] = {
   fun: pokaWordGet,
 };
 
+function pokaGetTry(stack: PokaValue[]): void {
+  const b = stack.pop();
+  if (b === undefined) {
+    throw "Stack underflow";
+  }
+
+  const a = stack.pop();
+  if (a === undefined) {
+    throw "Stack underflow";
+  }
+
+  const ar = pokaTryToRecord(a);
+
+  if (ar._type !== "PokaRecord") {
+    throw "Record must PokaRecord";
+  }
+
+  const bv = pokaTryToVector(b);
+  if (bv._type !== "PokaVectorString") {
+    throw "Key must be a PokaVectorString";
+  }
+
+  stack.push(pokaRecordGetTryVectorString(ar, bv));
+}
+
+POKA_WORDS4["getTry"] = {
+  doc: [
+    '[:"a" 1] ["b"] getTry [] equals',
+    '[:"a" 1, :"b" 2] ["b", "c"] getTry [2] equals all',
+  ],
+  fun: pokaGetTry,
+};
+
 function pokaWordDel(stack: PokaValue[]): void {
   const b = stack.pop();
   if (b === undefined) {


### PR DESCRIPTION
## Summary
- support retrieving optional keys from records via `getTry`
- add logic in `pokaRecord` to skip missing keys
- document and test the new `getTry` word

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68698d43c0a083329ad922913304b413