### PR TITLE
Implement contains for PokaRecord

### DIFF
--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -127,3 +127,37 @@ function pokaRecordEntryMakeVectorString(
   }
   return rec;
 }
+
+function pokaRecordContainsScalarString(
+  rec: PokaRecord,
+  key: PokaScalarString,
+): PokaScalarBoolean {
+  return pokaScalarBooleanMake(rec.value[key.value] !== undefined);
+}
+
+function pokaRecordContainsVectorString(
+  rec: PokaRecord,
+  keys: PokaVectorString,
+): PokaVectorBoolean {
+  const values: boolean[] = [];
+  for (const key of keys.values) {
+    values.push(rec.value[key] !== undefined);
+  }
+  return { _type: "PokaVectorBoolean", values };
+}
+
+function pokaRecordContainsMatrixString(
+  rec: PokaRecord,
+  keys: PokaMatrixString,
+): PokaMatrixBoolean {
+  const values: boolean[] = [];
+  for (const key of keys.values) {
+    values.push(rec.value[key] !== undefined);
+  }
+  return {
+    _type: "PokaMatrixBoolean",
+    countRows: keys.countRows,
+    countCols: keys.countCols,
+    values,
+  };
+}

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -1194,3 +1194,48 @@ POKA_WORDS4["del"] = {
   doc: ['[:"a" 1] "a" del [] equals'],
   fun: pokaWordDel,
 };
+
+function pokaWordContains(stack: PokaValue[]): void {
+  const b = stack.pop();
+  if (b === undefined) {
+    throw "Stack underflow";
+  }
+
+  const a = stack.pop();
+  if (a === undefined) {
+    throw "Stack underflow";
+  }
+
+  const ar = pokaTryToRecord(a);
+  if (ar._type !== "PokaRecord") {
+    throw "Record must PokaRecord";
+  }
+
+  if (b._type === "ScalarString") {
+    stack.push(pokaRecordContainsScalarString(ar, b));
+    return;
+  }
+
+  const bv = pokaTryToVector(b);
+  if (bv._type === "PokaVectorString") {
+    stack.push(pokaRecordContainsVectorString(ar, bv));
+    return;
+  }
+
+  const bm = pokaTryToMatrix(b);
+  if (bm._type === "PokaMatrixString") {
+    stack.push(pokaRecordContainsMatrixString(ar, bm));
+    return;
+  }
+
+  throw "Key must be a ScalarString";
+}
+
+POKA_WORDS4["contains"] = {
+  doc: [
+    '[:"a" 1] "a" contains True equals',
+    '[:"a" 1] ["a", "b"] contains [True, False] equals all',
+    '[:"a" 1] [["a", "b"], ["b", "a"]] contains [[True, False], [False, True]] equals all',
+  ],
+  fun: pokaWordContains,
+};


### PR DESCRIPTION
## Summary
- support checking if record contains scalar, vector or matrix keys
- wire up new helper functions and word `contains`
- document and test `contains` for scalar, vector and matrix cases

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686990cf93148332abfd78aee878df91