### PR TITLE
Implement slice word for matrices

### DIFF
--- a/src/MatrixBoolean.ts
+++ b/src/MatrixBoolean.ts
@@ -167,3 +167,29 @@ function pokaMatrixBooleanCount(a: PokaMatrixBoolean): number {
   }
   return acc;
 }
+
+function pokaMatrixBooleanSliceVectorBoolean(
+  a: PokaMatrixBoolean,
+  b: PokaVectorBoolean,
+): PokaMatrixBoolean {
+  if (b.values.length !== a.countRows) {
+    throw new Error("Shape mismatch");
+  }
+  let countRows = 0;
+  const values: boolean[] = [];
+  for (let i = 0; i < a.countRows; i++) {
+    if (b.values[i] === false) {
+      continue;
+    }
+    countRows = countRows + 1;
+    for (let j = 0; j < a.countCols; j++) {
+      values.push(a.values[i * a.countCols + j] as boolean);
+    }
+  }
+  return {
+    _type: "PokaMatrixBoolean",
+    countRows: countRows,
+    countCols: a.countCols,
+    values: values,
+  };
+}

--- a/src/MatrixNumber.ts
+++ b/src/MatrixNumber.ts
@@ -468,6 +468,32 @@ function pokaMatrixNumberRowsVectorBoolean(
   };
 }
 
+function pokaMatrixNumberSliceVectorBoolean(
+  a: PokaMatrixNumber,
+  b: PokaVectorBoolean,
+): PokaMatrixNumber {
+  if (b.values.length !== a.countRows) {
+    throw new Error("Shape mismatch");
+  }
+  let countRows = 0;
+  const values: number[] = [];
+  for (let i = 0; i < a.countRows; i++) {
+    if (b.values[i] === false) {
+      continue;
+    }
+    countRows = countRows + 1;
+    for (let j = 0; j < a.countCols; j++) {
+      values.push(a.values[i * a.countCols + j] as number);
+    }
+  }
+  return {
+    _type: "PokaMatrixNumber",
+    countRows: countRows,
+    countCols: a.countCols,
+    values: values,
+  };
+}
+
 function pokaMatrixNumberSqueeze(a: PokaMatrixNumber): PokaVectorNumber {
   if (a.countCols === 1) {
     return {

--- a/src/MatrixString.ts
+++ b/src/MatrixString.ts
@@ -256,3 +256,24 @@ function pokaMatrixStringColsVectorNumber(
   }
   return pokaMatrixStringMake(a.countRows, b.values.length, values);
 }
+
+function pokaMatrixStringSliceVectorBoolean(
+  a: PokaMatrixString,
+  b: PokaVectorBoolean,
+): PokaMatrixString {
+  if (b.values.length !== a.countRows) {
+    throw new Error("Shape mismatch");
+  }
+  let countRows = 0;
+  const values: string[] = [];
+  for (let i = 0; i < a.countRows; i++) {
+    if (b.values[i] === false) {
+      continue;
+    }
+    countRows = countRows + 1;
+    for (let j = 0; j < a.countCols; j++) {
+      values.push(a.values[i * a.countCols + j] as string);
+    }
+  }
+  return pokaMatrixStringMake(countRows, a.countCols, values);
+}

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -660,6 +660,49 @@ POKA_WORDS4["rows"] = {
   fun: pokaWordRows,
 };
 
+function pokaWordSlice(stack: PokaValue[]): void {
+  const b = stack.pop();
+  const a = stack.pop();
+
+  if (a === undefined || b === undefined) {
+    throw "Stack underflow";
+  }
+
+  const am = pokaTryToMatrix(a);
+  const bv = pokaTryToVector(b);
+
+  if (bv._type !== "PokaVectorBoolean") {
+    throw "Slice mask must be PokaVectorBoolean";
+  }
+
+  if (am._type === "PokaMatrixBoolean") {
+    stack.push(pokaMatrixBooleanSliceVectorBoolean(am, bv));
+    return;
+  }
+
+  if (am._type === "PokaMatrixNumber") {
+    stack.push(pokaMatrixNumberSliceVectorBoolean(am, bv));
+    return;
+  }
+
+  if (am._type === "PokaMatrixString") {
+    stack.push(pokaMatrixStringSliceVectorBoolean(am, bv));
+    return;
+  }
+
+  throw "No implementation";
+}
+
+POKA_WORDS4["slice"] = {
+  doc: [
+    "[[1, 2], [3, 4], [5, 6]] [True, False, True] slice [[1, 2], [5, 6]] equals all",
+    "[[1, 2, 3], [4, 5, 6]] [False, True] slice [[4, 5, 6]] equals all",
+    "[[True, False], [False, False], [True, True]] [True, False, True] slice [[True, False], [True, True]] equals all",
+    '[["a", "b"], ["c", "d"], ["e", "f"]] [False, True, True] slice [["c", "d"], ["e", "f"]] equals all',
+  ],
+  fun: pokaWordSlice,
+};
+
 function pokaWordSqueeze(stack: PokaValue[]): void {
   const a = stack.pop();
 


### PR DESCRIPTION
## Summary
- add doctest for numeric slice behavior
- fix matrix number slice implementation to match boolean and string versions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869a05600d0833290d2f2c4472f813b