### PR TITLE
Complete unequals word

### DIFF
--- a/src/MatrixBoolean.ts
+++ b/src/MatrixBoolean.ts
@@ -104,6 +104,25 @@ function pokaMatrixBooleanEqualsMatrixBoolean(
   };
 }
 
+function pokaMatrixBooleanUnequalsMatrixBoolean(
+  a: PokaMatrixBoolean,
+  b: PokaMatrixBoolean,
+): PokaMatrixBoolean {
+  if (a.countRows !== b.countRows || a.countCols !== b.countCols) {
+    throw "Shape mismatch";
+  }
+  const r: boolean[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    r.push(a.values[i] !== b.values[i]);
+  }
+  return {
+    _type: "PokaMatrixBoolean",
+    countRows: a.countRows,
+    countCols: a.countCols,
+    values: r,
+  };
+}
+
 function pokaMatrixBooleanAllRows(a: PokaMatrixBoolean): PokaMatrixBoolean {
   if (a.countCols === 0) {
     throw new Error("No columns");

--- a/src/MatrixString.ts
+++ b/src/MatrixString.ts
@@ -183,6 +183,25 @@ function pokaMatrixStringEqualsMatrixString(
   };
 }
 
+function pokaMatrixStringUnequalsMatrixString(
+  a: PokaMatrixString,
+  b: PokaMatrixString,
+): PokaMatrixBoolean {
+  if (a.countRows !== b.countRows || a.countCols !== b.countCols) {
+    throw "Shape mismatch";
+  }
+  const r: boolean[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    r.push(a.values[i] !== b.values[i]);
+  }
+  return {
+    _type: "PokaMatrixBoolean",
+    countRows: a.countRows,
+    countCols: a.countCols,
+    values: r,
+  };
+}
+
 function pokaMatrixStringToNumber(a: PokaMatrixString): PokaMatrixNumber {
   return pokaMatrixNumberMake(
     a.countRows,

--- a/src/VectorBoolean.ts
+++ b/src/VectorBoolean.ts
@@ -26,6 +26,17 @@ function pokaVectorBooleanEqualsVectorBoolean(
   return pokaVectorBooleanMake(r);
 }
 
+function pokaVectorBooleanUnequalsVectorBoolean(
+  a: PokaVectorBoolean,
+  b: PokaVectorBoolean,
+): PokaVectorBoolean {
+  const r: boolean[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    r.push(a.values[i] !== b.values[i]);
+  }
+  return pokaVectorBooleanMake(r);
+}
+
 function pokaVectorBooleanAndVectorBoolean(
   a: PokaVectorBoolean,
   b: PokaVectorBoolean,

--- a/src/VectorNumber.ts
+++ b/src/VectorNumber.ts
@@ -18,6 +18,17 @@ function pokaVectorNumberEqualsVectorNumber(
   return { _type: "PokaVectorBoolean", values: r };
 }
 
+function pokaVectorNumberUnequalsVectorNumber(
+  a: PokaVectorNumber,
+  b: PokaVectorNumber,
+): PokaVectorBoolean {
+  const r: boolean[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    r.push(a.values[i] !== b.values[i]);
+  }
+  return { _type: "PokaVectorBoolean", values: r };
+}
+
 function pokaVectorNumberSubVectorNumber(
   a: PokaVectorNumber,
   b: PokaVectorNumber,

--- a/src/VectorString.ts
+++ b/src/VectorString.ts
@@ -28,6 +28,20 @@ function pokaVectorStringEqualsVectorString(
   return { _type: "PokaVectorBoolean", values: r };
 }
 
+function pokaVectorStringUnequalsVectorString(
+  a: PokaVectorString,
+  b: PokaVectorString,
+): PokaVectorBoolean {
+  if (a.values.length !== b.values.length) {
+    throw "Shape mismatch";
+  }
+  const r: boolean[] = [];
+  for (let i = 0; i < a.values.length; i++) {
+    r.push(a.values[i] !== b.values[i]);
+  }
+  return { _type: "PokaVectorBoolean", values: r };
+}
+
 function pokaVectorStringShow(a: PokaVectorString): string {
   return "[" + a.values.map((x) => '"' + x + '"').join(", ") + "]";
 }

--- a/src/pokaList.ts
+++ b/src/pokaList.ts
@@ -32,6 +32,11 @@ function pokaListEqualsPokaList(a: PokaList, b: PokaList): PokaScalarBoolean {
   return pokaScalarBooleanMake(true);
 }
 
+function pokaListUnequalsPokaList(a: PokaList, b: PokaList): PokaScalarBoolean {
+  const eq = pokaListEqualsPokaList(a, b);
+  return pokaScalarBooleanMake(!eq.value);
+}
+
 function pokaListEnumerate(a: PokaList): PokaVectorNumber {
   const values: number[] = [];
   for (let i = 0; i < a.value.length; i++) {

--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -42,6 +42,14 @@ function pokaRecordEqualsPokaRecord(
   return pokaScalarBooleanMake(true);
 }
 
+function pokaRecordUnequalsPokaRecord(
+  a: PokaRecord,
+  b: PokaRecord,
+): PokaScalarBoolean {
+  const eq = pokaRecordEqualsPokaRecord(a, b);
+  return pokaScalarBooleanMake(!eq.value);
+}
+
 function pokaRecordGetScalarString(
   rec: PokaRecord,
   key: PokaScalarString,

--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -1066,25 +1066,23 @@ function pokaWordUnequals(stack: PokaValue[]): void {
     return;
   }
 
-  /*
-    const av = pokaTryToVector(a);
-    const bv = pokaTryToVector(b);
-  
-    if (av._type === "PokaVectorBoolean" && bv._type === "PokaVectorBoolean") {
-      stack.push(pokaVectorBooleanUnequalsVectorBoolean(av, bv));
-      return;
-    }
-  
-    if (av._type === "PokaVectorNumber" && bv._type === "PokaVectorNumber") {
-      stack.push(pokaVectorNumberUnequalsVectorNumber(av, bv));
-      return;
-    }
-  
-    if (av._type === "PokaVectorString" && bv._type === "PokaVectorString") {
-      stack.push(pokaVectorStringUnequalsVectorString(av, bv));
-      return;
-    }
-    */
+  const av = pokaTryToVector(a);
+  const bv = pokaTryToVector(b);
+
+  if (av._type === "PokaVectorBoolean" && bv._type === "PokaVectorBoolean") {
+    stack.push(pokaVectorBooleanUnequalsVectorBoolean(av, bv));
+    return;
+  }
+
+  if (av._type === "PokaVectorNumber" && bv._type === "PokaVectorNumber") {
+    stack.push(pokaVectorNumberUnequalsVectorNumber(av, bv));
+    return;
+  }
+
+  if (av._type === "PokaVectorString" && bv._type === "PokaVectorString") {
+    stack.push(pokaVectorStringUnequalsVectorString(av, bv));
+    return;
+  }
 
   const am = pokaTryToMatrix(a);
 
@@ -1095,32 +1093,47 @@ function pokaWordUnequals(stack: PokaValue[]): void {
 
   const bm = pokaTryToMatrix(b);
 
-  /*
-    if (am._type === "PokaMatrixBoolean" && bm._type === "PokaMatrixBoolean") {
-      stack.push(pokaMatrixBooleanUnequalsMatrixBoolean(am, bm));
-      return;
-    }
-    */
+  if (am._type === "PokaMatrixBoolean" && bm._type === "PokaMatrixBoolean") {
+    stack.push(pokaMatrixBooleanUnequalsMatrixBoolean(am, bm));
+    return;
+  }
 
   if (am._type === "PokaMatrixNumber" && bm._type === "PokaMatrixNumber") {
     stack.push(pokaMatrixNumberUnequalsMatrixNumber(am, bm));
     return;
   }
 
-  /*
-    if (am._type === "PokaMatrixString" && bm._type === "PokaMatrixString") {
-      stack.push(pokaMatrixStringUnequalsMatrixString(am, bm));
-      return;
-    }
-    */
+  if (am._type === "PokaMatrixString" && bm._type === "PokaMatrixString") {
+    stack.push(pokaMatrixStringUnequalsMatrixString(am, bm));
+    return;
+  }
+
+  const ar = pokaTryToRecord(a);
+  const br = pokaTryToRecord(b);
+
+  if (ar._type === "PokaRecord" && br._type === "PokaRecord") {
+    stack.push(pokaRecordUnequalsPokaRecord(ar, br));
+    return;
+  }
+
+  if (a._type === "List" && b._type === "List") {
+    stack.push(pokaListUnequalsPokaList(a, b));
+    return;
+  }
 
   throw "No implementation";
 }
 
 POKA_WORDS4["unequals"] = {
   doc: [
+    "1 2 unequals True equals",
     "[[1, 2]] [[2, 2]] unequals [[True, False]] equals all",
     "[[1, 2]] 2 unequals [[True, False]] equals all",
+    "[1, 2] [1, 3] unequals [False, True] equals all",
+    "[True, 1] [True, 1] unequals False equals",
+    "[True, 1] [True, 2] unequals True equals",
+    '[:"a" 1] [:"a" 1] unequals False equals',
+    '[:"a" 1] [:"a" 2] unequals True equals',
   ],
   fun: pokaWordUnequals,
 };


### PR DESCRIPTION
## Summary
- finalize `pokaWordUnequals` and cover all value types
- add unequals helpers for vectors, matrices, lists and records
- extend documentation tests for `unequals`
- add additional doc tests for heterogenous lists and for PokaRecord

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a41057b5c8332910bf8185ceeb3d6