### PR TITLE
Remove scope syntax

### DIFF
--- a/src/aoc2025.ts
+++ b/src/aoc2025.ts
@@ -37,7 +37,7 @@ const AOC2025: {
     input_name: "aoc2025day3a",
     answer: 161,
     program: [
-      '$aoc2025day3a "mul\\((\\d+),(\\d+)\\)" match {0 cols toNumber, 1 cols toNumber} mul sum',
+      '$aoc2025day3a "mul\\((\\d+),(\\d+)\\)" match [0 cols toNumber, 1 cols toNumber] spread mul sum',
     ],
   },
   day4a: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,39 +286,6 @@ function consumeString(state: InterpreterState): void {
   state.stack.push(pokaScalarStringMake(value));
 }
 
-function peekScope(state: InterpreterState): boolean {
-  return peekLiteral(state, "{");
-}
-
-function consumeScope(state: InterpreterState): void {
-  const values: PokaValue[] = [];
-  const origStack = state.stack;
-
-  consumeLiteral(state, "{");
-  while (!peekLiteral(state, "}") && !peekEOL(state)) {
-    state.stack = origStack.slice();
-    while (!peekLiteral(state, "}") && !peekEOL(state)) {
-      if (peekLiteral(state, ",")) {
-        consumeLiteral(state, ",");
-        break;
-      }
-      consumeExpression(state);
-    }
-    const value = state.stack.pop();
-    if (value === undefined) {
-      throw "Stack empty in fork expression";
-    } else {
-      values.push(value);
-    }
-  }
-  consumeLiteral(state, "}");
-
-  state.stack = origStack;
-
-  for (const value of values) {
-    state.stack.push(value);
-  }
-}
 
 function peekList(state: InterpreterState): boolean {
   return peekLiteral(state, "[");
@@ -459,8 +426,6 @@ function consumeExpression(state: InterpreterState): void {
     consumeNumber(state);
   } else if (peekString(state)) {
     consumeString(state);
-  } else if (peekScope(state)) {
-    consumeScope(state);
   } else if (peekList(state)) {
     consumeList(state);
   } else {


### PR DESCRIPTION
## Summary
- drop `{}` expression form from interpreter
- use `[ ] spread` for AoC test instead

## Testing
- `npx tsc`
- `node run_tests.js`

------
https://chatgpt.com/codex/tasks/task_e_686a96758e4483328e6d62aa5bbc5c9b