### PR TITLE
Move pokaListMake and refactor list creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,11 +85,6 @@ function pokaInterpreterShow(state: InterpreterState): string {
 }
 
 
-function pokaListMake(values: PokaValue[]): PokaList {
-  return { _type: "List", value: values };
-}
-
-
 
 function pokaTryToVector(value: PokaValue): PokaValue {
   if (value._type !== "List") {

--- a/src/pokaList.ts
+++ b/src/pokaList.ts
@@ -3,34 +3,35 @@ interface PokaList {
   value: PokaValue[];
 }
 
+function pokaListMake(values: PokaValue[]): PokaList {
+  return { _type: "List", value: values };
+}
+
 function pokaListTryFrom(value: PokaValue): PokaList | null {
   if (value._type === "List") {
     return value;
   }
   if (value._type === "PokaVectorBoolean") {
-    return {
-      _type: "List",
-      value: value.values.map((v) => pokaScalarBooleanMake(v)),
-    };
+    return pokaListMake(
+      value.values.map((v) => pokaScalarBooleanMake(v)),
+    );
   }
   if (value._type === "PokaVectorNumber") {
-    return {
-      _type: "List",
-      value: value.values.map((v) => pokaScalarNumberMake(v)),
-    };
+    return pokaListMake(
+      value.values.map((v) => pokaScalarNumberMake(v)),
+    );
   }
   if (value._type === "PokaVectorString") {
-    return {
-      _type: "List",
-      value: value.values.map((v) => pokaScalarStringMake(v)),
-    };
+    return pokaListMake(
+      value.values.map((v) => pokaScalarStringMake(v)),
+    );
   }
   if (value._type === "PokaRecord") {
     const entries: PokaRecordEntry[] = [];
     for (const [key, val] of Object.entries(value.value)) {
       entries.push({ _type: "RecordEntry", key, value: val });
     }
-    return { _type: "List", value: entries };
+    return pokaListMake(entries);
   }
   return null;
 }
@@ -115,7 +116,7 @@ function pokaListSliceVectorNumber(
     }
     values.push(elem);
   }
-  return { _type: "List", value: values };
+  return pokaListMake(values);
 }
 
 function pokaListSliceVectorBoolean(
@@ -135,5 +136,5 @@ function pokaListSliceVectorBoolean(
       values.push(elem);
     }
   }
-  return { _type: "List", value: values };
+  return pokaListMake(values);
 }

--- a/src/pokaRecord.ts
+++ b/src/pokaRecord.ts
@@ -73,7 +73,7 @@ function pokaRecordGetVectorString(
     }
     values.push(value);
   }
-  return { _type: "List", value: values };
+  return pokaListMake(values);
 }
 
 function pokaRecordGetTryVectorString(
@@ -87,7 +87,7 @@ function pokaRecordGetTryVectorString(
       values.push(value);
     }
   }
-  return { _type: "List", value: values };
+  return pokaListMake(values);
 }
 
 function pokaRecordGetMatrixString(
@@ -106,9 +106,9 @@ function pokaRecordGetMatrixString(
       }
       rowVals.push(value);
     }
-    rows.push({ _type: "List", value: rowVals });
+    rows.push(pokaListMake(rowVals));
   }
-  return { _type: "List", value: rows };
+  return pokaListMake(rows);
 }
 
 function pokaRecordEntryMakeScalarString(


### PR DESCRIPTION
## Summary
- move `pokaListMake` implementation to `pokaList.ts`
- use `pokaListMake` anywhere a list is constructed

## Testing
- `npx tsc`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bf0fd93d4833295174546a3863c8e