### PR TITLE
Split sigil identifiers in lexer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,8 +128,8 @@ function consumeExpression(state: InterpreterState): void {
   }
   if (token._kind === "SigilIdentifier") {
     pokaLexerPop(state, "SigilIdentifier");
-    if (token.text.startsWith("$")) {
-      const variableName = token.text.slice(1);
+    if (token.sigil === "$") {
+      const variableName = token.value;
       const value = state.env[variableName];
       if (value === undefined) {
         throw "No such variable: " + variableName;
@@ -137,8 +137,8 @@ function consumeExpression(state: InterpreterState): void {
       state.stack.push(value);
       return;
     }
-    if (token.text.startsWith("=")) {
-      const variableName = token.text.slice(1);
+    if (token.sigil === "=") {
+      const variableName = token.value;
       const value = state.stack.pop();
       if (value === undefined) {
         throw "Stack underflow";

--- a/src/pokaLexer.ts
+++ b/src/pokaLexer.ts
@@ -15,7 +15,8 @@ interface PokaLexemePlainIdentifier {
 
 interface PokaLexemeSigilIdentifier {
   _kind: "SigilIdentifier";
-  text: string;
+  sigil: string;
+  value: string;
 }
 
 interface PokaLexemeForm {
@@ -218,8 +219,9 @@ function pokaLexerConsumePlainIdentifier(state: PokaLexerState): void {
 }
 
 function pokaLexerConsumeSigilIdentifier(state: PokaLexerState): void {
-  const start = state.pos;
+  const sigil = state.line.charAt(state.pos);
   state.pos++; // consume sigil
+  const start = state.pos;
   while (true) {
     const c = state.line.charAt(state.pos);
     if (
@@ -234,7 +236,8 @@ function pokaLexerConsumeSigilIdentifier(state: PokaLexerState): void {
   }
   state.lexemes.push({
     _kind: "SigilIdentifier",
-    text: state.line.slice(start, state.pos),
+    sigil,
+    value: state.line.slice(start, state.pos),
   });
 }
 
@@ -365,8 +368,8 @@ const POKA_LEXER_TESTS: [string, PokaLexeme[]][] = [
     '"hi" =a $a',
     [
       { _kind: "String", text: "hi" },
-      { _kind: "SigilIdentifier", text: "=a" },
-      { _kind: "SigilIdentifier", text: "$a" },
+      { _kind: "SigilIdentifier", sigil: "=", value: "a" },
+      { _kind: "SigilIdentifier", sigil: "$", value: "a" },
     ],
   ],
   [
@@ -440,6 +443,13 @@ function pokaLexerTestsRun(): string {
             const g = got as PokaLexemeNumber;
             const e = exp as PokaLexemeNumber;
             if (g.value !== e.value) {
+              ok = false;
+              break;
+            }
+          } else if (got._kind === "SigilIdentifier") {
+            const g = got as PokaLexemeSigilIdentifier;
+            const e = exp as PokaLexemeSigilIdentifier;
+            if (g.sigil !== e.sigil || g.value !== e.value) {
               ok = false;
               break;
             }


### PR DESCRIPTION
## Summary
- support separate `sigil` and `value` fields for sigil identifiers
- parse sigil/value in lexer
- update tests and interpreter for new format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873570438208332929fd5041b0e6a1e