### PR TITLE
Improve consumeExpression error reporting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -154,31 +154,20 @@ function consumePlainIdentifier(state: InterpreterState): void {
 }
 
 function consumeExpression(state: InterpreterState): void {
-  if (peekEOL(state)) {
-    throw "Expected expression";
-  }
   const token = pokaLexerPeek(state);
   if (token._kind === "Number") {
     consumeNumber(state);
-    return;
-  }
-  if (token._kind === "String") {
+  } else if (token._kind === "String") {
     consumeString(state);
-    return;
-  }
-  if (token._kind === "SigilIdentifier") {
+  } else if (token._kind === "SigilIdentifier") {
     consumeSigilIdentifier(state);
-    return;
-  }
-  if (token._kind === "PlainIdentifier") {
+  } else if (token._kind === "PlainIdentifier") {
     consumePlainIdentifier(state);
-    return;
-  }
-  if (token._kind === "ListStart") {
+  } else if (token._kind === "ListStart") {
     consumeList(state);
-    return;
+  } else {
+    throw "Unexpected token: `" + pokaLexerShowLexeme(token) + "`";
   }
-  throw "Expected expression";
 }
 
 function pokaInterpreterMake(

--- a/src/pokaLexer.ts
+++ b/src/pokaLexer.ts
@@ -409,6 +409,29 @@ function pokaLexerPopListEnd(cursor: PokaLexerCursor): PokaLexemeListEnd {
   return lex;
 }
 
+function pokaLexerShowLexeme(lex: PokaLexeme): string {
+  switch (lex._kind) {
+    case "Number":
+      return lex.value.toString();
+    case "String":
+      return '"' + lex.text + '"';
+    case "PlainIdentifier":
+      return lex.text;
+    case "SigilIdentifier":
+      return lex.sigil + lex.value;
+    case "Form":
+      return lex.text;
+    case "Comma":
+      return ",";
+    case "Symbol":
+      return lex.text;
+    case "ListStart":
+      return "[";
+    case "ListEnd":
+      return "]";
+  }
+}
+
 const POKA_LEXER_TESTS: [string, PokaLexeme[]][] = [
   [
     "1 2 add",


### PR DESCRIPTION
## Summary
- add `pokaLexerShowLexeme` for human readable lexeme display
- simplify `consumeExpression` control flow and show unexpected token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687368ded964833290797f96690ca6b0