### PR TITLE
Implement lexer peekEOL helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,17 +67,13 @@ function pokaInterpreterShow(state: InterpreterState): string {
   return state.error + "\n" + result.join("\n");
 }
 
-function peekEOL(state: InterpreterState): boolean {
-  return state.pos >= state.lexemes.length;
-}
-
 function consumeList(state: InterpreterState): void {
   const values: PokaValue[] = [];
   const origStack = state.stack;
   pokaLexerPopListStart(state);
-  while (!peekEOL(state) && pokaLexerPeek(state)._kind !== "ListEnd") {
+  while (pokaLexerPeek(state)._kind !== "ListEnd") {
     state.stack = origStack.slice();
-    while (!peekEOL(state) && pokaLexerPeek(state)._kind !== "ListEnd") {
+    while (pokaLexerPeek(state)._kind !== "ListEnd") {
       if (pokaLexerPeek(state)._kind === "Comma") {
         pokaLexerPopComma(state);
         break;
@@ -180,7 +176,7 @@ function pokaInterpreterEvaluate(state: InterpreterState): void {
   }
   let error = "";
   try {
-    while (!peekEOL(state)) {
+    while (!pokaLexerPeekEOL(state)) {
       consumeExpression(state);
     }
   } catch (exc) {

--- a/src/pokaLexer.ts
+++ b/src/pokaLexer.ts
@@ -333,6 +333,10 @@ function pokaLexerPeek(cursor: PokaLexerCursor): PokaLexeme {
   return lex;
 }
 
+function pokaLexerPeekEOL(cursor: PokaLexerCursor): boolean {
+  return cursor.pos >= cursor.lexemes.length;
+}
+
 function pokaLexerPopNumber(cursor: PokaLexerCursor): PokaLexemeNumber {
   const lex = pokaLexerPeek(cursor);
   if (lex._kind !== "Number") {


### PR DESCRIPTION
## Summary
- implement `pokaLexerPeekEOL` helper in lexer
- drop internal `peekEOL` from interpreter
- rely on lexer helper in interpreter evaluation
- simplify list parsing loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687378506c1483329cbf918805498471