### PR TITLE
Fix pokaWordAll doc test for matrices

### DIFF
--- a/src/pokaWords.ts
+++ b/src/pokaWords.ts
@@ -29,8 +29,8 @@ POKA_WORDS4["all"] = {
     "[true, true] all true equals",
     "[false, false] all false equals",
     "[true, false] all false equals",
-    "[[true, true] [true, true]] all true equals",
-    "[[true, false] [false, true]] all false equals",
+    "[[true, true], [true, true]] all true equals",
+    "[[true, false], [false, true]] all false equals",
   ],
   fun: pokaWordAll,
 };


### PR DESCRIPTION
## Summary
- correct doc test matrix syntax in `pokaWordAll`
- ensure tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687384c88f888332900a0818cd282c5b