### PR TITLE
Fix newline escapes in lexer strings

### DIFF
--- a/src/pokaLexer.ts
+++ b/src/pokaLexer.ts
@@ -193,7 +193,7 @@ function pokaLexerConsumeString(state: PokaLexerState): void {
   state.pos++; // closing quote
   state.lexemes.push({
     _kind: "String",
-    text: value,
+    text: value.replace(/\\n/g, "\n"),
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure `pokaLexerConsumeString` converts `\n` escapes to newline characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873c4b2cc148332a6927d480c0b5404