### PR TITLE
Refactor lexer tests

### DIFF
--- a/src/pokaTestsCommon.ts
+++ b/src/pokaTestsCommon.ts
@@ -9,7 +9,7 @@ const POKA_TESTS = [
 
 function pokaTestsRun(): string {
   const result: string[] = [];
-  result.push(...pokaLexerTestsRun().split("\n"));
+  result.push(...pokaLexerRunTests().split("\n"));
   for (const expr of POKA_TESTS) {
     try {
       const state = pokaInterpreterMake(expr, {});


### PR DESCRIPTION
## Summary
- inline test names instead of using a variable within lexer test functions
- maintain sequential execution of lexer unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687562d0600083328e6cd23c2d9319e3