### PR TITLE
Fix TRY/CATCH lexer test

### DIFF
--- a/src/pokaLexer.ts
+++ b/src/pokaLexer.ts
@@ -618,6 +618,10 @@ function pokaLexerRunTest(testCase: PokaLexerTestCase): void {
       pokaLexerPopListStart(state);
     } else if (expected._kind === "ListEnd" && got._kind === "ListEnd") {
       pokaLexerPopListEnd(state);
+    } else if (expected._kind === "StartScope" && got._kind === "StartScope") {
+      pokaLexerPopStartScope(state);
+    } else if (expected._kind === "EndScope" && got._kind === "EndScope") {
+      pokaLexerPopEndScope(state);
     } else {
       throw (
         "pokaLexerRunTests: Expected: " +


### PR DESCRIPTION
## Summary
- handle StartScope and EndScope tokens in lexer tests
- update lexer test runner so TRY/CATCH case passes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cbd4daea483328a74b30ad2748b00